### PR TITLE
feat(ai, testing): Introduce AI Model Mocking Utility and Optional MCPAIAgent Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![Python](https://img.shields.io/badge/python-3.12-blue)
 
 A utility package for AI solutions.
-There are two packages:
 
 * [ai](doc/ai.md) - abstraction layer and utilities for LLMs:
   * OpenAI
@@ -11,6 +10,7 @@ There are two packages:
   * DeepSeek
   * Anthropic
 * [pipelines](doc/pipelines.md) - framework for buiding pipelines
+* [testing](doc/testing.md) - package with testing utitlities
 
 ## Build and publish
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,61 @@
+# Testing package
+
+## mocker_ai_model fixture / MockerAIModel
+
+`mocker_ai_model` fixture provide object of MockerAIModel class. It mocks calls to LLM classes:
+
+* `GoogleAIModel`
+* `OpenAIModel`
+* `DeepSeekAIModel`
+* `AnthropicAIModel`
+
+Both sync and async methods are supported.
+
+### Methods
+
+* add() - adds a mocked AI response.
+  * response (str | AIChatResponse): The response to return.
+  * message (Optional[str], optional): The exact message string to match. Defaults to None.
+  * message_containing (Optional[str], optional): A substring that should be contained in the message. Defaults to None.
+  * tool_result (Optional[str], optional): The tool result to match. Defaults to None.
+  * blob_contents (Optional[List[bytes]], optional): The blob contents to match. Defaults to None.
+* record() - records all AI responses and prints them to console.
+
+### Use case
+
+Recording calls and responses to AI models for later mocking.
+
+```python
+def test_recording(mocker_ai_model: MockerAIModel):  # noqa: F811
+    # Given: A real AI model
+    ai_model = OpenAIModel(parameters={"temperature": 0})
+    with pytest.raises(AssertionError):
+        # When: AI model calls are recorded
+        with mocker_ai_model.record():
+            response = ai_model.get_chat_response(
+                message=AIModelInteractionMessage(role="user", content="Who was the first US president?")
+            )
+            # Then: A real answer is returned
+            assert response.content
+            assert "George Washington" in response.content
+        # And: AssertionError is raised by record() method
+        assert False
+        # And: Calls are printed in console
+```
+
+Mocking responses from AI models.
+
+```python
+def test_get_chat_response(ai_model: BaseAIModel, mocker_ai_model: MockerAIModel):  # noqa: F811
+    # Given: A mock with an interaction defined
+    mocker_ai_model.add(
+        message="Who was the first US president?",
+        response="George Washington.",
+    )
+    # When: get_chat_response() for AI model is called
+    response = ai_model.get_chat_response(
+        message=AIModelInteractionMessage(role="user", content="Who was the first US president?")
+    )
+    # Then: The mock returns a defined response
+    assert response.content == "George Washington."
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "haintech"
-version = "0.4.7"
+version = "0.5.2"
 license = "MIT"
 description = "Add your description here"
 readme = "README.md"
@@ -15,6 +15,9 @@ dependencies = [
     "openai>=1.68.2",
     "pydantic>=2.10.6",
 ]
+
+[project.entry-points.pytest11]
+haintech = "haintech.testing.plugin"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/haintech/ai/__init__.py
+++ b/src/haintech/ai/__init__.py
@@ -1,17 +1,18 @@
 from .base import (
+    BaseAgentSearcher,
     BaseAIAgent,
     BaseAIAgentAsync,
     BaseAIChat,
     BaseAIChatAsync,
     BaseAIModel,
     BaseAISupervisor,
-    BaseRAGSearcher,
-    BaseAgentSearcher,
     BaseAITextEmbeddingModel,
+    BaseRAGSearcher,
 )
 from .model import (
     AIChatResponse,
     AIChatSession,
+    AIContext,
     AIFunction,
     AIFunctionParameter,
     AIModelInteraction,
@@ -19,14 +20,16 @@ from .model import (
     AIModelSession,
     AIModelToolCall,
     AIPrompt,
-    AIContext,
     AISupervisorSession,
     AITask,
     RAGItem,
     RAGQuery,
 )
 from .ai_task_executor import AITaskExecutor
-from .mcp_ai_agent import MCPAIAgent
+try:
+    from .mcp_ai_agent import MCPAIAgent
+except ImportError:
+    pass
 
 
 __all__ = [

--- a/src/haintech/testing/__init__.py
+++ b/src/haintech/testing/__init__.py
@@ -1,0 +1,7 @@
+try:
+    from .mocker_ai_model import MockerAIModel, mocker_ai_model
+
+    __all__ = ["MockerAIModel", "mocker_ai_model"]
+
+except ImportError:
+    pass

--- a/src/haintech/testing/mocker_ai_model.py
+++ b/src/haintech/testing/mocker_ai_model.py
@@ -1,0 +1,211 @@
+import json
+import logging
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Iterable, List, Literal, Optional
+
+import pytest
+from haintech.ai import AIChatResponse, AIContext, AIModelInteraction, AIModelInteractionMessage, AIPrompt
+from pydantic import BaseModel, field_serializer
+from pytest_mock.plugin import MockerFixture
+
+try:
+    from haintech.ai.google_generativeai import GoogleAIModel  # noqa: F401
+
+    GOOGLE_AVAILABLE = True
+except ImportError:
+    GOOGLE_AVAILABLE = False
+
+try:
+    from haintech.ai.open_ai import OpenAIModel  # noqa: F401
+
+    OPENAI_AVAILABLE = True
+except ImportError:
+    OPENAI_AVAILABLE = False
+
+try:
+    from haintech.ai.anthropic import AnthropicAIModel  # noqa: F401
+
+    ANTHROPIC_AVAILABLE = True
+except ImportError:
+    ANTHROPIC_AVAILABLE = False
+
+try:
+    from haintech.ai.deep_seek import DeepSeekAIModel  # noqa: F401
+
+    DEEPSEEK_AVAILABLE = True
+except ImportError:
+    DEEPSEEK_AVAILABLE = False
+
+_log = logging.getLogger(__name__)
+
+
+class AICall(BaseModel):
+    message_str: Optional[str] = None
+    message_containing: Optional[str] = None
+    blob_contents: Optional[List[bytes]] = None
+    tool_result: Optional[str] = None
+    response: AIChatResponse
+
+    @field_serializer("blob_contents")
+    def serialize_blobs(self, value: Optional[List[bytes]]) -> Optional[List[str]]:
+        if value is None:
+            return None
+        return [repr(b) for b in value]
+
+
+class MockerAIModel:
+    _mocked_methods: List[str] = []
+    
+    if GOOGLE_AVAILABLE:
+        _mocked_methods.append("haintech.ai.google_generativeai.GoogleAIModel.get_chat_response")
+        _mocked_methods.append("haintech.ai.google_generativeai.GoogleAIModel.get_chat_response_async")
+    if OPENAI_AVAILABLE:
+        _mocked_methods.append("haintech.ai.open_ai.OpenAIModel.get_chat_response")
+        _mocked_methods.append("haintech.ai.open_ai.OpenAIModel.get_chat_response_async")
+    if ANTHROPIC_AVAILABLE:
+        _mocked_methods.append("haintech.ai.anthropic.AnthropicAIModel.get_chat_response")
+        _mocked_methods.append("haintech.ai.anthropic.AnthropicAIModel.get_chat_response_async")
+    if DEEPSEEK_AVAILABLE:
+        _mocked_methods.append("haintech.ai.deep_seek.DeepSeekAIModel.get_chat_response")
+        _mocked_methods.append("haintech.ai.deep_seek.DeepSeekAIModel.get_chat_response_async")
+
+    def __init__(self, mocker: MockerFixture):
+        self.mocker = mocker
+        self.org_ai_model = None
+        self.responses: List[AICall] = []
+        self.setup()
+
+    def setup(self) -> None:
+        for method in self._mocked_methods:
+            self.mocker.patch(method, side_effect=self.get_chat_response)
+
+    @contextmanager
+    def record(self):
+        """Records all AI responses and prints them to console."""
+        from haintech.ai.google_generativeai import GoogleAIModel, GoogleAIParameters
+
+        self.org_ai_model = GoogleAIModel(parameters=GoogleAIParameters(temperature=0))
+        yield
+        print(
+            json.dumps(
+                [call.model_dump(mode="python", exclude_none=True, exclude_unset=True) for call in self.responses],
+                indent=2,
+            )
+        )
+        assert False
+
+    def add(
+        self,
+        response: str | AIChatResponse,
+        message: Optional[str] = None,
+        message_containing: Optional[str] = None,
+        tool_result: Optional[str] = None,
+        blob_contents: Optional[List[bytes]] = None,
+    ) -> None:
+        """Adds a mocked AI response.
+
+        Args:
+            response (str | AIChatResponse): The response to return.
+            message (Optional[str], optional): The exact message string to match. Defaults to None.
+            message_containing (Optional[str], optional): A substring that should be contained in the message. Defaults to None.
+            tool_result (Optional[str], optional): The tool result to match. Defaults to None.
+            blob_contents (Optional[List[bytes]], optional): The blob contents to match. Defaults to None.
+        """
+        if isinstance(response, str):
+            response_obj = AIChatResponse(content=response)
+        else:
+            response_obj = response
+        self.responses.append(
+            AICall(
+                response=response_obj,
+                message_str=message,
+                message_containing=message_containing,
+                blob_contents=blob_contents,
+                tool_result=tool_result,
+            )
+        )
+
+    def get_chat_response(
+        self,
+        system_prompt: Optional[str | AIPrompt] = None,
+        history: Optional[Iterable[AIModelInteractionMessage]] = None,
+        context: Optional[AIContext] = None,
+        message: Optional[AIModelInteractionMessage] = None,
+        functions: Optional[Dict[Callable, Any]] = None,
+        interaction_logger: Optional[Callable[[AIModelInteraction], None]] = None,
+        response_format: Literal["text", "json"] = "text",
+    ) -> AIChatResponse:
+        history = list(history or [])
+        if history and history[-1].role == "tool":
+            tool_result = history[-1].content
+        else:
+            tool_result = None
+
+        #####################
+
+        if self.org_ai_model:
+            self.mocker.stopall()
+            response = self.org_ai_model.get_chat_response(
+                system_prompt=system_prompt,
+                history=history,
+                context=context,
+                message=message,
+                functions=functions,
+                interaction_logger=interaction_logger,
+                response_format=response_format,
+            )
+
+            call = AICall(
+                message_str=message.content if message else None,
+                blob_contents=[blob.content for blob in message.blobs] if message and message.blobs else None,
+                tool_result=tool_result,
+                response=response,
+            )
+            _log.info("AI response: %s", response)
+            self.responses.append(call)
+            self.setup()
+            return response
+        elif not self.responses:
+            raise RuntimeError("No mocked AI responses available.")
+        else:
+            call = self.responses.pop(0)
+            if call.message_str:
+                assert message and message.content
+                assert message.content == call.message_str, (
+                    f"Expected message content '{call.message_str}', got '{message.content}'"
+                )
+            if call.message_containing:
+                assert message and message.content
+                assert call.message_containing in message.content
+            if call.blob_contents:
+                assert message and message.blobs
+                assert len(call.blob_contents) == len(message.blobs), (
+                    f"Expected {len(call.blob_contents)} blobs, got {len(message.blobs)}"
+                )
+                assert all([blob.content in call.blob_contents for blob in message.blobs]), (
+                    f"Expected blobs {call.blob_contents}, got {[blob.content for blob in message.blobs]}"
+                )
+            if call.tool_result:
+                assert tool_result
+                assert tool_result == call.tool_result, (
+                    f"Expected tool result '{call.tool_result}', got '{tool_result}'"
+                )
+            response = call.response
+
+        ####################
+        if interaction_logger:
+            interaction_logger(
+                AIModelInteraction(
+                    model="MockerAIModel",
+                    message=message,
+                    context=context,
+                    history=history,
+                    response=response,
+                )
+            )
+        return response
+
+
+@pytest.fixture
+def mocker_ai_model(mocker: MockerFixture) -> MockerAIModel:
+    return MockerAIModel(mocker)

--- a/src/haintech/testing/plugin.py
+++ b/src/haintech/testing/plugin.py
@@ -1,0 +1,6 @@
+try:
+    import pytest_mock  # noqa: F401
+    from .mocker_ai_model import mocker_ai_model  # noqa: F401
+
+except ImportError:
+    pass

--- a/tests/testing/test_mocker_ai_model.py
+++ b/tests/testing/test_mocker_ai_model.py
@@ -1,0 +1,64 @@
+import pytest
+
+from haintech.ai.anthropic.anthropic_ai_model import AnthropicAIModel
+from haintech.ai.base.base_ai_model import BaseAIModel
+from haintech.ai.deep_seek.deep_seek_ai_model import DeepSeekAIModel
+from haintech.ai.google_generativeai.google_ai_model import GoogleAIModel
+from haintech.ai.model import AIModelInteractionMessage
+from haintech.ai.open_ai.open_ai_model import OpenAIModel
+from haintech.testing.mocker_ai_model import MockerAIModel, mocker_ai_model  # noqa: F401
+
+
+@pytest.fixture(
+    params=[OpenAIModel, GoogleAIModel, DeepSeekAIModel, AnthropicAIModel],
+    # params=[GoogleAIModel],
+    scope="function",
+)
+def ai_model(request: pytest.FixtureRequest) -> BaseAIModel:
+    return request.param(parameters={"temperature": 0})
+
+
+def test_get_chat_response(ai_model: BaseAIModel, mocker_ai_model: MockerAIModel):  # noqa: F811
+    # Given: A mock with an interaction defined
+    mocker_ai_model.add(
+        message="Who was the first US president?",
+        response="George Washington.",
+    )
+    # When: get_chat_response() for AI model is called
+    response = ai_model.get_chat_response(
+        message=AIModelInteractionMessage(role="user", content="Who was the first US president?")
+    )
+    # Then: The mock returns a defined response
+    assert response.content == "George Washington."
+
+
+@pytest.mark.asyncio
+async def test_get_chat_response_async(ai_model: BaseAIModel, mocker_ai_model: MockerAIModel):  # noqa: F811
+    # Given: A mock with an interaction defined
+    mocker_ai_model.add(
+        message="Who was the first US president?",
+        response="George Washington.",
+    )
+    # When: get_chat_response() for AI model is called
+    response = await ai_model.get_chat_response_async(
+        message=AIModelInteractionMessage(role="user", content="Who was the first US president?")
+    )
+    # Then: The mock returns a defined response
+    assert response.content == "George Washington."
+
+
+def test_recording(mocker_ai_model: MockerAIModel):  # noqa: F811
+    # Given: A real AI model
+    ai_model = OpenAIModel(parameters={"temperature": 0})
+    with pytest.raises(AssertionError):
+        # When: AI model calls are recorded
+        with mocker_ai_model.record():
+            response = ai_model.get_chat_response(
+                message=AIModelInteractionMessage(role="user", content="Who was the first US president?")
+            )
+            # Then: A real answer is returned
+            assert response.content
+            assert "George Washington" in response.content
+        # And: AssertionError is raised by record() method
+        assert False
+        # And: Calls are printed in console


### PR DESCRIPTION
This pull request introduces a new `testing` package with utilities for mocking AI model responses and includes a fix to make `MCPAIAgent` import optional.

**Key Changes:**

- **AI Model Mocking Utility:**
    - Added a new `testing` package providing `MockerAIModel` class and `mocker_ai_model` pytest fixture.
    - Enables mocking of `get_chat_response` and `get_chat_response_async` for Google, OpenAI, DeepSeek, and Anthropic AI models.
    - Introduced a `record` context manager to capture and print actual AI model interactions, aiding in mock generation.
    - Updated `pyproject.toml` to register the `testing` package as a pytest plugin and increment the version.
    - Included comprehensive documentation (`doc/testing.md`) and tests for the new mocking functionality.
- **Optional `MCPAIAgent` Import:**
    - Implemented a `try-except ImportError` block for `MCPAIAgent` in `src/haintech/ai/__init__.py`, making its import optional and preventing errors if `openai-agents` is not installed.

This update significantly improves the testability of AI-powered applications by providing robust mocking capabilities for various LLMs.