### PR TITLE
feat(ai): Add Google and OpenAI image generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A utility package for AI solutions.
   * DeepSeek
   * Anthropic
   * [prompts](doc/ai/prompts.md) - prompt management
+  * [image generators](doc/ai/image_generators.md) - utilities for image generation models
 * [pipelines](doc/pipelines.md) - framework for buiding pipelines
 * [testing](doc/testing.md) - package with testing utitlities
 

--- a/doc/ai/image_generators.md
+++ b/doc/ai/image_generators.md
@@ -1,0 +1,87 @@
+# Image Generators
+
+the components for generating images using Google GenAI and OpenAI, returning `BlobCreate` objects for consistent data handling.
+
+## BaseImageGenerator
+
+An abstract base class defining the interface for all image generators.
+
+### Methods
+
+* `generate(prompt: str)` - Synchronous generator yielding `BlobCreate` objects.
+* `generate_async(prompt: str)` - Asynchronous generator yielding `BlobCreate` objects.
+
+## Implementations
+
+### GenAIImageGenerator (Google)
+
+Uses the Google GenAI SDK. Default model: `gemini-2.5-flash-image`.
+
+### OpenAIImageGenerator (OpenAI)
+
+Uses the OpenAI SDK. Default model: `gpt-image-1-mini`. Automatically handles `b64_json` response format for DALL-E models.
+
+## Usage Examples
+
+### Synchronous Generation (Google GenAI)
+
+```python
+from haintech.ai.google_genai import GenAIImageGenerator
+
+# Initialize with API key
+generator = GenAIImageGenerator(api_key="your_google_api_key")
+
+# Generate images (returns a generator of BlobCreate)
+for blob in generator.generate("A futuristic city in the clouds, digital art"):
+    print(f"Generated image type: {blob.metadata.content_type}")
+    # Access raw bytes via blob.content
+    with open("output.png", "wb") as f:
+        f.write(blob.content)
+```
+
+### Asynchronous Generation (OpenAI)
+
+```python
+import asyncio
+from haintech.ai.open_ai import OpenAIImageGenerator
+
+async def main():
+    # Initialize with specific model
+    generator = OpenAIImageGenerator(model_name="dall-e-3", api_key="your_openai_api_key")
+
+    # Use asynchronous generator
+    async for blob in generator.generate_async("A cute robot drinking coffee"):
+        print(f"Received image: {blob.metadata.content_type}")
+        # blob.content contains the image data
+
+asyncio.run(main())
+```
+
+### Class-level Configuration
+
+Both generators support a class-level `setup()` method to configure the client once for the entire application.
+
+```python
+from haintech.ai.open_ai import OpenAIImageGenerator
+
+# Configure once
+OpenAIImageGenerator.setup(api_key="your_api_key")
+
+# Create instances without passing the key again
+generator = OpenAIImageGenerator(model_name="dall-e-2")
+```
+
+## Integration with ampf
+
+The generators return `ampf.base.BlobCreate` objects, making it easy to upload results directly to storage:
+
+```python
+from ampf.base import Blob
+# ... generator setup ...
+
+blob_create = next(generator.generate("A black dog"))
+blob_create.name = "dog_image.png"
+
+# Upload using ampf storage
+blob_storage.upload(Blob.create(blob_create))
+```

--- a/src/haintech/ai/__init__.py
+++ b/src/haintech/ai/__init__.py
@@ -8,6 +8,7 @@ from .base import (
     BaseAISupervisor,
     BaseAITextEmbeddingModel,
     BaseRAGSearcher,
+    BaseImageGenerator,
 )
 from .model import (
     AIAgentInteraction,
@@ -58,6 +59,7 @@ __all__ = [
     "BaseAITextEmbeddingModel",
     "BaseRAGSearcher",
     "BaseAgentSearcher",
+    "BaseImageGenerator",
     "AIFunction",
     "AIFunctionParameter",
     "AITask",

--- a/src/haintech/ai/base/__init__.py
+++ b/src/haintech/ai/base/__init__.py
@@ -9,6 +9,8 @@ from .base_ai_text_embedding_model import BaseAITextEmbeddingModel
 from .base_rag_searcher import BaseRAGSearcher
 from .base_agent_searcher import BaseAgentSearcher
 
+from .base_image_generator import BaseImageGenerator
+
 
 __all__ = [
     "BaseRAGSearcher",
@@ -20,4 +22,5 @@ __all__ = [
     "BaseAIAgentAsync",
     "BaseAISupervisor",
     "BaseAITextEmbeddingModel",
+    "BaseImageGenerator",
 ]

--- a/src/haintech/ai/base/base_image_generator.py
+++ b/src/haintech/ai/base/base_image_generator.py
@@ -1,0 +1,14 @@
+from abc import ABC
+from typing import AsyncGenerator, Generator
+
+from ampf.base import BlobCreate
+
+
+class BaseImageGenerator(ABC):
+
+    def generate(self, prompt: str) -> Generator[BlobCreate]:
+        raise NotImplementedError()
+
+    async def generate_async(self, prompt: str) -> AsyncGenerator[BlobCreate]:
+        for blob_create in self.generate(prompt):
+            yield blob_create

--- a/src/haintech/ai/google_genai/__init__.py
+++ b/src/haintech/ai/google_genai/__init__.py
@@ -1,6 +1,8 @@
 from .google_ai_model import GoogleAIModel, GoogleAIParameters
+from .genai_image_generator import GenAIImageGenerator
 
 __all__ = [
     "GoogleAIModel",
-    "GoogleAIParameters"
+    "GoogleAIParameters",
+    "GenAIImageGenerator",
 ]

--- a/src/haintech/ai/google_genai/genai_image_generator.py
+++ b/src/haintech/ai/google_genai/genai_image_generator.py
@@ -1,0 +1,87 @@
+import logging
+from typing import AsyncGenerator, Generator
+
+from ampf.base import BlobCreate
+from google import genai
+from google.genai import types
+
+from haintech.ai.base.base_image_generator import BaseImageGenerator
+
+
+_log = logging.getLogger(__name__)
+
+
+class GenAIImageGenerator(BaseImageGenerator):
+    _configured = False
+
+    def __init__(self, model_name: str = "gemini-2.5-flash-image", api_key: str | None = None):
+        if api_key:
+            self.setup(api_key=api_key)
+        self.model_name = model_name
+
+    @classmethod
+    def setup(cls, api_key: str | None = None):
+        if not cls._configured:
+            cls.client = genai.Client(api_key=api_key)
+            cls._configured = True
+            _log.debug("Google AI Model configured")
+
+    def generate(self, prompt: str) -> Generator[BlobCreate]:
+        if not self._configured:
+            self.setup()
+        contents = [types.Content(role="user", parts=[types.Part.from_text(text=prompt)])]
+        generate_content_config = types.GenerateContentConfig(
+            response_modalities=["IMAGE"], image_config=types.ImageConfig(aspect_ratio="1:1")
+        )
+        for chunk in self.client.models.generate_content_stream(
+            model=self.model_name,
+            contents=contents,
+            config=generate_content_config,
+        ):
+            if (
+                chunk.candidates is None
+                or chunk.candidates[0].content is None
+                or chunk.candidates[0].content.parts is None
+            ):
+                continue
+            if chunk.candidates[0].content.parts[0].inline_data:
+                inline_data = chunk.candidates[0].content.parts[0].inline_data
+                if inline_data.data and inline_data.mime_type:
+                    yield BlobCreate.from_content(
+                        content_type=inline_data.mime_type,
+                        content=inline_data.data,
+                    )
+                else:
+                    _log.warning("No binary data!?")
+            else:
+                _log.info(chunk.text)
+
+    async def generate_async(self, prompt: str) -> AsyncGenerator[BlobCreate]:
+        if not self._configured:
+            self.setup()
+        contents = [types.Content(role="user", parts=[types.Part.from_text(text=prompt)])]
+        generate_content_config = types.GenerateContentConfig(
+            response_modalities=["IMAGE"], image_config=types.ImageConfig(aspect_ratio="1:1")
+        )
+        async for chunk in await self.client.aio.models.generate_content_stream(
+            model=self.model_name,
+            contents=contents,
+            config=generate_content_config,
+        ):
+            if (
+                chunk.candidates is None
+                or chunk.candidates[0].content is None
+                or chunk.candidates[0].content.parts is None
+            ):
+                continue
+            if chunk.candidates[0].content.parts[0].inline_data:
+                inline_data = chunk.candidates[0].content.parts[0].inline_data
+                if inline_data.data and inline_data.mime_type:
+                    yield BlobCreate.from_content(
+                        content_type=inline_data.mime_type,
+                        content=inline_data.data,
+                    )
+                else:
+                    _log.warning("No binary data!?")
+            else:
+                _log.info(chunk.text)

--- a/src/haintech/ai/open_ai/__init__.py
+++ b/src/haintech/ai/open_ai/__init__.py
@@ -3,6 +3,8 @@ from .open_ai_agent import OpenAIAgent
 from .open_ai_chat import OpenAIChat
 from .open_ai_model import OpenAIModel
 from .open_ai_text_embedding_model import OpenAITextEmbeddingModel
+from .open_ai_image_generator import OpenAIImageGenerator
+
 
 __all__ = [
     "OpenAIModel",
@@ -10,4 +12,5 @@ __all__ = [
     "OpenAIChat",
     "OpenAIAgent",
     "OpenAITextEmbeddingModel",
+    "OpenAIImageGenerator",
 ]

--- a/src/haintech/ai/open_ai/open_ai_image_generator.py
+++ b/src/haintech/ai/open_ai/open_ai_image_generator.py
@@ -1,0 +1,69 @@
+import base64
+import logging
+from typing import Any, AsyncGenerator, Generator
+
+from ampf.base import BlobCreate
+from openai import AsyncOpenAI, OpenAI
+
+from haintech.ai.base.base_image_generator import BaseImageGenerator
+
+_log = logging.getLogger(__name__)
+
+
+class OpenAIImageGenerator(BaseImageGenerator):
+    _configured = False
+
+    def __init__(self, model_name: str = "gpt-image-1-mini", api_key: str | None = None):
+        if api_key:
+            self.setup(api_key=api_key)
+        self.model_name = model_name
+
+    @classmethod
+    def setup(cls, api_key: str | None = None):
+        if not cls._configured:
+            cls.client = OpenAI(api_key=api_key)
+            cls.async_openai = AsyncOpenAI(api_key=api_key)
+            cls._configured = True
+            _log.debug("OpenAI AI Model configured")
+
+    def _prepare_parameters(self) -> dict[str, Any]:
+        if not self._configured:
+            self.setup()
+        if "dall-e" in self.model_name:
+            return {"response_format": "b64_json"}
+        else:
+            return {}
+
+    def generate(self, prompt: str) -> Generator[BlobCreate]:
+        parameters = self._prepare_parameters()
+        result = self.client.images.generate(
+            model=self.model_name,
+            prompt=prompt,
+            size="1024x1024",
+            n=1,
+            **parameters,
+        )
+        if result.data:
+            for data in result.data:
+                image_bytes = base64.b64decode(data.b64_json)
+                yield BlobCreate.from_content(
+                    content_type=f"image/{result.output_format or 'png'}",
+                    content=image_bytes,
+                )
+
+    async def generate_async(self, prompt: str) -> AsyncGenerator[BlobCreate]:
+        parameters = self._prepare_parameters()
+        result = await self.async_openai.images.generate(
+            model=self.model_name,
+            prompt=prompt,
+            size="1024x1024",
+            n=1,
+            **parameters,
+        )
+        if result.data:
+            for data in result.data:
+                image_bytes = base64.b64decode(data.b64_json)
+                yield BlobCreate.from_content(
+                    content_type=f"image/{result.output_format or 'png'}",
+                    content=image_bytes,
+                )

--- a/tests/ai/all/test_all_image_gen_service.py
+++ b/tests/ai/all/test_all_image_gen_service.py
@@ -1,0 +1,28 @@
+import pytest
+
+from haintech.ai.base.base_image_generator import BaseImageGenerator
+from haintech.ai.google_genai.genai_image_generator import GenAIImageGenerator
+from haintech.ai.open_ai.open_ai_image_generator import OpenAIImageGenerator
+
+
+@pytest.fixture(scope="module", params=[OpenAIImageGenerator, GenAIImageGenerator])
+def service(request) -> BaseImageGenerator:
+    return request.param()
+
+
+@pytest.mark.skip(reason="It generates costs.")
+def test_generate(service: BaseImageGenerator):
+    blob_create = next(service.generate("Big black dog."))
+
+    assert blob_create.metadata
+    assert blob_create.metadata.content_type
+    assert blob_create.content
+
+
+@pytest.mark.skip(reason="It generates costs.")
+@pytest.mark.asyncio
+async def test_generate_async(service: BaseImageGenerator):
+    async for blob_create in service.generate_async("Big black dog."):
+        assert blob_create.metadata
+        assert blob_create.metadata.content_type
+        assert blob_create.content

--- a/tests/ai/test_google_genai_image_generator.py
+++ b/tests/ai/test_google_genai_image_generator.py
@@ -1,0 +1,40 @@
+from ampf.local import LocalFactory
+from ampf.base import BaseBlobStorage, Blob
+import pytest
+
+from haintech.ai.google_genai.genai_image_generator import GenAIImageGenerator
+
+
+@pytest.fixture(scope="module", params=["gemini-2.5-flash-image", "gemini-3.1-flash-image-preview"])
+def service(request) -> GenAIImageGenerator:
+    return GenAIImageGenerator(model_name=request.param)
+
+
+@pytest.fixture
+def blob_storage():
+    factory = LocalFactory("./tests/data/")
+    return factory.create_blob_storage("images")
+
+
+@pytest.mark.skip(reason="It generates costs.")
+def test_generate(service: GenAIImageGenerator, blob_storage: BaseBlobStorage):
+    blob_create = next(service.generate("Big black dog."))
+
+    assert blob_create.metadata
+    assert blob_create.metadata.content_type
+    assert blob_create.content
+
+    blob_create.name = service.model_name + ".png"
+    blob_storage.upload(Blob.create(blob_create))
+
+
+@pytest.mark.skip(reason="It generates costs.")
+@pytest.mark.asyncio
+async def test_generate_async(service: GenAIImageGenerator, blob_storage: BaseBlobStorage):
+    async for blob_create in service.generate_async("Big black dog."):
+        assert blob_create.metadata
+        assert blob_create.metadata.content_type
+        assert blob_create.content
+
+        blob_create.name = f"async_{service.model_name}.png"
+        blob_storage.upload(Blob.create(blob_create))

--- a/tests/ai/test_open_ai_image_generator.py
+++ b/tests/ai/test_open_ai_image_generator.py
@@ -1,0 +1,39 @@
+from ampf.local import LocalFactory
+from ampf.base import BaseBlobStorage, Blob
+import pytest
+
+from haintech.ai.open_ai.open_ai_image_generator import OpenAIImageGenerator
+
+
+@pytest.fixture(scope="module", params=["dall-e-3", "dall-e-2", "gpt-image-1", "gpt-image-1-mini", "gpt-image-1.5"])
+def service(request) -> OpenAIImageGenerator:
+    return OpenAIImageGenerator(model_name=request.param)
+
+
+@pytest.fixture
+def blob_storage():
+    factory = LocalFactory("./tests/data/")
+    return factory.create_blob_storage("images")
+
+
+@pytest.mark.skip(reason="It generates costs.")
+def test_generate(service: OpenAIImageGenerator, blob_storage: BaseBlobStorage):
+    blob_create = next(service.generate("Big black dog."))
+
+    assert blob_create.metadata
+    assert blob_create.metadata.content_type
+    assert blob_create.content
+
+    blob_create.name = service.model_name + ".png"
+    blob_storage.upload(Blob.create(blob_create))
+
+@pytest.mark.skip(reason="It generates costs.")
+@pytest.mark.asyncio
+async def test_generate_async(service: OpenAIImageGenerator, blob_storage: BaseBlobStorage):
+    async for blob_create in service.generate_async("Big black dog."):
+        assert blob_create.metadata
+        assert blob_create.metadata.content_type
+        assert blob_create.content
+
+        blob_create.name = f"async_{service.model_name}.png"
+        blob_storage.upload(Blob.create(blob_create))


### PR DESCRIPTION
This pull request introduces new image generation capabilities for Google GenAI and OpenAI.

Key changes include:
- Implementation of `BaseImageGenerator` abstract class.
- Addition of `GenAIImageGenerator` for Google GenAI and `OpenAIImageGenerator` for OpenAI.
- Support for both synchronous and asynchronous image generation methods.
- Integration with `ampf.base.BlobCreate` for consistent data handling.
- Comprehensive documentation for the new image generators.
- Addition of unit tests for all new generators and their async variants.
- Updates to `README.md` to reflect the new functionality.